### PR TITLE
[QNEBE-425] catch json file not found

### DIFF
--- a/src/cli/exceptions.py
+++ b/src/cli/exceptions.py
@@ -8,7 +8,7 @@ class MalformedJsonFile(QneCliException):
     """Raised when trying to read a file containing malformed json """
 
     def __init__(self, file_name: str, e: Exception) -> None:
-        super().__init__(f'The file {file_name} does not contain valid json. Error: {e}')
+        super().__init__(f"The file '{file_name}' does not contain valid json. {e}")
 
 
 class ApplicationAlreadyExists(QneCliException):
@@ -94,7 +94,7 @@ class NotEnoughRoles(QneCliException):
 class JsonFileNotFound(QneCliException):
     """Json file not found that was expected"""
     def __init__(self, file_name: str) -> None:
-        super().__init__(f'File {file_name} not found')
+        super().__init__(f"File '{file_name}' not found")
 
 
 class PackageNotComplete(QneCliException):

--- a/src/cli/exceptions.py
+++ b/src/cli/exceptions.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 
 
 class QneCliException(Exception):
@@ -8,8 +7,8 @@ class QneCliException(Exception):
 class MalformedJsonFile(QneCliException):
     """Raised when trying to read a file containing malformed json """
 
-    def __init__(self, path: Path, e: Exception) -> None:
-        super().__init__(f'The file {path} does not contain valid json. Error: {e}')
+    def __init__(self, file_name: str, e: Exception) -> None:
+        super().__init__(f'The file {file_name} does not contain valid json. Error: {e}')
 
 
 class ApplicationAlreadyExists(QneCliException):
@@ -90,6 +89,20 @@ class NotEnoughRoles(QneCliException):
 
     def __init__(self) -> None:
         super().__init__("The number of roles must be higher than one")
+
+
+class JsonFileNotFound(QneCliException):
+    """Json file not found that was expected"""
+    def __init__(self, file_name: str) -> None:
+        super().__init__(f'File {file_name} not found')
+
+
+class PackageNotComplete(QneCliException):
+    """Essential package file is missing"""
+
+    def __init__(self, file_name: str) -> None:
+        super().__init__(f'File {file_name} not found. This file is essential for the correct operation of '
+                         f'this package. Please reinstall the package')
 
 
 class RolesNotUnique(QneCliException):

--- a/src/cli/utils.py
+++ b/src/cli/utils.py
@@ -26,10 +26,10 @@ def read_json_file(file_name: Path, encoding: str = 'utf-8') -> Any:
     try:
         with open(file_name, encoding=encoding) as fp:
             return json.load(fp)
-    except FileNotFoundError as file_error:
-        raise JsonFileNotFound(str(file_name)) from file_error
+    except FileNotFoundError:
+        raise JsonFileNotFound(str(file_name)) from None
     except json.decoder.JSONDecodeError as json_error:
-        raise MalformedJsonFile(str(file_name), json_error) from json_error
+        raise MalformedJsonFile(str(file_name), json_error) from None
 
 
 def write_json_file(file_name: Path, data: Any, encoding: str = 'utf-8') -> None:

--- a/src/cli/utils.py
+++ b/src/cli/utils.py
@@ -26,8 +26,8 @@ def read_json_file(file_name: Path, encoding: str = 'utf-8') -> Any:
     try:
         with open(file_name, encoding=encoding) as fp:
             return json.load(fp)
-    except FileNotFoundError:
-        raise JsonFileNotFound(str(file_name))
+    except FileNotFoundError as file_error:
+        raise JsonFileNotFound(str(file_name)) from file_error
     except json.decoder.JSONDecodeError as json_error:
         raise MalformedJsonFile(str(file_name), json_error) from json_error
 

--- a/src/cli/utils.py
+++ b/src/cli/utils.py
@@ -4,57 +4,60 @@ from pathlib import Path
 import shutil
 from typing import Any, Dict, List, Optional
 
-from cli.exceptions import MalformedJsonFile, InvalidPathName
+from cli.exceptions import JsonFileNotFound, MalformedJsonFile, InvalidPathName
 
 
-def read_json_file(file: Path, encoding: str = 'utf-8') -> Any:
+def read_json_file(file_name: Path, encoding: str = 'utf-8') -> Any:
     """
-    Open the 'file' in 'encoding' format & read the data from the file
+    Open the file in 'encoding' format & read the data from the file
 
     Args:
-        file: Path specifying the json file to be read
+        file_name: Path specifying the json file to be read
         encoding: Encoding format in which to open the file
 
     Returns:
         The data read from json file
 
     Raises:
+        JsonFileNotFound: If the file doesn't exist
         MalformedJsonFile: If the file contains invalid json
     """
 
     try:
-        with open(file, encoding=encoding) as fp:
+        with open(file_name, encoding=encoding) as fp:
             return json.load(fp)
-    except json.decoder.JSONDecodeError as exception:
-        raise MalformedJsonFile(file, exception) from exception
+    except FileNotFoundError:
+        raise JsonFileNotFound(str(file_name))
+    except json.decoder.JSONDecodeError as json_error:
+        raise MalformedJsonFile(str(file_name), json_error) from json_error
 
 
-def write_json_file(file: Path, data: Any, encoding: str = 'utf-8') -> None:
+def write_json_file(file_name: Path, data: Any, encoding: str = 'utf-8') -> None:
     """
-    Open the 'file' & write the 'data' to the 'file'
+    Open the file & write the data to the file
 
     Args:
-        file: Path specifying the json file to be written to
+        file_name: Path specifying the json file to be written to
         data: Data to be written to file
         encoding: Encoding format in which to open the file
 
     """
 
-    with open(file, mode="w", encoding=encoding) as fp:
+    with open(file_name, mode="w", encoding=encoding) as fp:
         json.dump(data, fp, indent=2)
 
 
-def write_file(file: Path, data: Any, encoding: str = 'utf-8') -> None:
+def write_file(file_name: Path, data: Any, encoding: str = 'utf-8') -> None:
     """
-     Open the 'file' & write the 'data' to the 'file'
+     Open the file & write the data to the file
 
     Args:
-        file: Path specifying the file to be written to
+        file_name: Path specifying the file to be written to
         data: Data to be written to file
         encoding: Encoding format in which to open the file
     """
 
-    with open(file, mode="w", encoding=encoding) as fp:
+    with open(file_name, mode="w", encoding=encoding) as fp:
         fp.write(data)
 
 

--- a/src/cli/validators.py
+++ b/src/cli/validators.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Tuple, Any
 from jsonschema import Draft7Validator, RefResolver, draft7_format_checker
 from jsonschema.exceptions import ValidationError
+
+from cli.exceptions import JsonFileNotFound, PackageNotComplete
 from cli.utils import read_json_file
 
 
@@ -20,7 +22,10 @@ def validate_json_file(instance_path: Path) -> Tuple[bool, Any]:
 def validate_json_schema(instance_path: Path, schema_path: Path) -> Tuple[bool, Any]:
     try:
         json_file = read_json_file(instance_path)
-        json_schema = read_json_file(schema_path)
+        try:
+            json_schema = read_json_file(schema_path)
+        except JsonFileNotFound:
+            raise PackageNotComplete(str(schema_path)) from None
         if platform.system() == 'Windows':
             path = os.path.dirname(schema_path)
             json_schema_full_path = os.path.realpath(path).replace('\\', '/')

--- a/src/cli/validators.py
+++ b/src/cli/validators.py
@@ -1,22 +1,22 @@
 import platform
 import os
-import json
 from pathlib import Path
 from typing import Tuple, Any
 from jsonschema import Draft7Validator, RefResolver, draft7_format_checker
 from jsonschema.exceptions import ValidationError
 
-from cli.exceptions import JsonFileNotFound, PackageNotComplete
+from cli.exceptions import JsonFileNotFound, MalformedJsonFile, PackageNotComplete
 from cli.utils import read_json_file
 
 
-def validate_json_file(instance_path: Path) -> Tuple[bool, Any]:
+def validate_json_file(file_name: Path) -> Tuple[bool, Any]:
     try:
-        with open(instance_path, encoding="utf-8") as fp:
-            json.load(fp)
+        read_json_file(file_name)
         return True, None
-    except Exception as e:
-        return False, f"{instance_path} contains invalid json. {e}"
+    except JsonFileNotFound as file_error:
+        raise file_error
+    except MalformedJsonFile as e:
+        return False, str(e)
 
 
 def validate_json_schema(instance_path: Path, schema_path: Path) -> Tuple[bool, Any]:

--- a/src/tests/api/test_local_api.py
+++ b/src/tests/api/test_local_api.py
@@ -5,7 +5,7 @@ from unittest.mock import call, patch, MagicMock
 from cli.managers.roundset_manager import RoundSetManager
 from cli.api.local_api import LocalApi
 from cli.output_converter import OutputConverter
-from cli.exceptions import ApplicationAlreadyExists, NoNetworkAvailable
+from cli.exceptions import ApplicationAlreadyExists, JsonFileNotFound, NoNetworkAvailable, PackageNotComplete
 
 
 class ApplicationValidate(unittest.TestCase):
@@ -157,6 +157,11 @@ class ApplicationValidate(unittest.TestCase):
             }
           ]
         }
+
+    def test_constructor(self):
+        with patch("cli.api.local_api.utils.read_json_file") as read_json_file_mock:
+            read_json_file_mock.side_effect = JsonFileNotFound("networks/networks.json")
+            self.assertRaises(PackageNotComplete, LocalApi, self.config_manager)
 
     def test_create_application(self):
         with patch.object(self.config_manager, "application_exists") as application_exists_mock, \

--- a/src/tests/test_validators.py
+++ b/src/tests/test_validators.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import patch
 import unittest
+
+from cli.exceptions import JsonFileNotFound, PackageNotComplete
 from cli.validators import validate_json_file, validate_json_schema
 
 
@@ -10,6 +12,20 @@ class TestValidators(unittest.TestCase):
         self.path = Path("dummy")
         self.roles = ["role1", "role2"]
         self.invalid_name = "invalid/name"
+
+    def test_json_schema_not_found(self):
+        json_file = {
+            "application": [
+                {
+                    "title": "Title for this application",
+                    "description": "Description of this application"
+                }
+            ]
+        }
+
+        with patch("cli.validators.read_json_file") as read_json_file_mock:
+            read_json_file_mock.side_effect = [json_file, JsonFileNotFound("schema/applications/application.json")]
+            self.assertRaises(PackageNotComplete, validate_json_schema, self.path, self.path)
 
     def test_validate_json_schema(self):
         with patch("cli.validators.read_json_file") as read_json_file_mock, \


### PR DESCRIPTION
* read json now raises JsonFileNotFound when file not there
* In case of json not found for essential package files (schema's, network) a separate error is raised PackageNotComplete
* PackageNotComplete is not showing the complete stack trace but only the error that is essential
* Some boy scouting here and there
* validate_json_file now uses read_json_file