### PR TITLE
[QNE-NNN] Delete other directories when some directory was not deleted

### DIFF
--- a/src/cli/api/local_api.py
+++ b/src/cli/api/local_api.py
@@ -794,15 +794,15 @@ class LocalApi:
         if experiment_path.is_dir() and experiment_json.is_file():
             experiment_input_path = experiment_path / 'input'
             if experiment_input_path.is_dir():
-                all_subdir_deleted = all_subdir_deleted and self._delete_input(experiment_input_path)
+                all_subdir_deleted = self._delete_input(experiment_input_path) and all_subdir_deleted
 
             experiment_raw_output_path = experiment_path / 'raw_output'
             if experiment_raw_output_path.is_dir():
-                all_subdir_deleted = all_subdir_deleted and self._delete_raw_output(experiment_raw_output_path)
+                all_subdir_deleted = self._delete_raw_output(experiment_raw_output_path) and all_subdir_deleted
 
             experiment_results_path = experiment_path / 'results'
             if experiment_results_path.is_dir():
-                all_subdir_deleted = all_subdir_deleted and self._delete_results(experiment_results_path)
+                all_subdir_deleted = self._delete_results(experiment_results_path) and all_subdir_deleted
 
             # Delete experiment.json
             experiment_json.unlink()


### PR DESCRIPTION
* Bug was in execution and operator. Had to change order to: bool = method_call() and bool (left part is now always executed)
* Created unit test for this bug
