### PR TITLE
[QNEBE-434] Application-delete-local

### DIFF
--- a/src/cli/api/local_api.py
+++ b/src/cli/api/local_api.py
@@ -4,9 +4,9 @@ import shutil
 from typing import Any, cast, Dict, List, Optional
 
 from cli import utils
-from cli.exceptions import (ApplicationAlreadyExists, DirectoryAlreadyExists, ExperimentDirectoryNotValid,
-                            JsonFileNotFound, MalformedJsonFile, NetworkNotFound, NoNetworkAvailable,
-                            PackageNotComplete)
+from cli.exceptions import (ApplicationAlreadyExists, ApplicationDoesNotExist, DirectoryAlreadyExists,
+                            ExperimentDirectoryNotValid, JsonFileNotFound, MalformedJsonFile, NetworkNotFound,
+                            NoNetworkAvailable, PackageNotComplete)
 from cli.managers.config_manager import ConfigManager
 from cli.managers.roundset_manager import RoundSetManager
 from cli.generators.network_generator import FullyConnectedNetworkGenerator
@@ -302,6 +302,107 @@ class LocalApi:
         """
         local_applications = self.__config_manager.get_applications()
         return local_applications
+
+    def _delete_src(self, application_path: Path) -> bool:
+        """Config directory contains configuration files"""
+        src_dir_deleted = False
+        application_src_path = application_path / 'src'
+        # read the network config for the app file names in src
+        application_config_path = application_path / 'config'
+        if application_config_path.is_dir():
+            config_network_file = application_config_path / 'network.json'
+            if config_network_file.is_file():
+                # Delete the app files for the roles from network.json from the
+                # application/src directory
+                application_file_names = [application_src_path / application_file_name for
+                                          application_file_name in
+                                          self.__get_role_file_names(application_config_path)]
+                for app_file in application_file_names:
+                    if app_file.is_file():
+                        app_file.unlink()
+
+        try:
+            os.rmdir(application_src_path)
+            src_dir_deleted = True
+        except OSError:  # The directory is not empty
+            pass
+
+        return src_dir_deleted
+
+    def _delete_config(self, application_path: Path) -> bool:
+        """Config directory contains configuration files"""
+        config_dir_deleted = False
+        application_config_path = application_path / 'config'
+        config_files_list = self.__get_config_file_names()
+        for config_file in config_files_list:
+            file_to_delete = application_config_path / config_file
+            if file_to_delete.is_file():
+                file_to_delete.unlink()
+
+        try:
+            os.rmdir(application_config_path)
+            config_dir_deleted = True
+        except OSError:  # The directory is not empty
+            pass
+
+        return config_dir_deleted
+
+    def delete_application(self, application_name: Optional[str], path: Path) -> bool:
+        """
+        Deletes the application files.
+        When application name is None the current directory is taken as application path, the application files and
+        directories are deleted but the current directory cannot be deleted, leaving a trace of the application.
+        When application name is given ./application is taken as application path and the
+        application_name directory can also be deleted deleting the complete application.
+        Only files that belong to an application are deleted. When a directory is not empty it is not deleted.
+
+        Args:
+            application_name: Optional. The application directory deleted will be ./application_name, otherwise the
+            current directory
+            path: The location of the application
+
+        Returns:
+            True if the complete application (including directory application_name) was deleted, otherwise false
+            (leaving traces of the application)
+
+        Raises:
+            ExperimentDirectoryNotValid when the application path is not recognized as an application
+        """
+        application_dir_deleted = False
+        all_subdir_deleted = True
+        application_path = path / application_name if application_name is not None else path
+        # check if the application exists and save the app name to delete it later
+        application_name_from_config, _ = self.__config_manager.get_application_from_path(application_path)
+
+        # Check if application path exists
+        if application_path.is_dir():
+            application_src_path = application_path / 'src'
+            if application_src_path.is_dir():
+                all_subdir_deleted = self._delete_src(application_path) and all_subdir_deleted
+
+            application_config_path = application_path / 'config'
+            if application_config_path.is_dir():
+                all_subdir_deleted = self._delete_config(application_path) and all_subdir_deleted
+
+            # Delete manifest.ini
+            manifest_ini = application_path / 'MANIFEST.ini'
+            if manifest_ini.is_file():
+                manifest_ini.unlink()
+
+            # only when we called application delete from the parent directory and all subdirs were removed try to
+            # remove application dir
+            if all_subdir_deleted and application_name is not None:
+                try:
+                    os.rmdir(application_path)
+                    application_dir_deleted = True
+                except OSError:  # The directory is not empty
+                    pass
+        else:
+            raise ApplicationDoesNotExist(str(application_path))
+
+        # remove application from configuration
+        self.__config_manager.delete_application(application_name_from_config)
+        return all_subdir_deleted and application_dir_deleted
 
     def is_application_valid(self, application_name: str) -> ErrorDictType:
         """
@@ -807,8 +908,8 @@ class LocalApi:
             # Delete experiment.json
             experiment_json.unlink()
 
-            # only when we called experiment delete from the parent directory and 'input' dir was removed try to remove
-            # experiment dir
+            # only when we called experiment delete from the parent directory and all the subdirectories were
+            # removed try to remove experiment dir
             if all_subdir_deleted and experiment_name is not None:
                 try:
                     os.rmdir(experiment_path)

--- a/src/cli/api/local_api.py
+++ b/src/cli/api/local_api.py
@@ -350,15 +350,16 @@ class LocalApi:
     def delete_application(self, application_name: Optional[str], path: Path) -> bool:
         """
         Deletes the application files.
-        When application name is None the current directory is taken as application path, the application files and
-        directories are deleted but the current directory cannot be deleted, leaving a trace of the application.
-        When application name is given ./application is taken as application path and the
-        application_name directory can also be deleted deleting the complete application.
+        When application name is None the current directory is taken as application path
+        When application name is given ./application is taken as application path. When this path is invalid we try
+        to get the application path from the configuration.
+        The application files and subdirectories are deleted. Only when the current directory is the
+        application directory the current directory cannot be deleted, leaving a trace of the application.
         Only files that belong to an application are deleted. When a directory is not empty it is not deleted.
 
         Args:
-            application_name: Optional. The application directory deleted will be ./application_name, otherwise the
-            current directory
+            application_name: Optional. The application directory deleted will be ./application_name, the
+            current directory or the application path registered in application config for application_name
             path: The location of the application
 
         Returns:
@@ -371,6 +372,10 @@ class LocalApi:
         application_dir_deleted = False
         all_subdir_deleted = True
         application_path = path / application_name if application_name is not None else path
+        # When we are not in the directory of the application, get the directory from the config
+        if not application_path.is_dir() and application_name is not None:
+            application_path = Path(self.__config_manager.get_application_path(application_name))
+
         # check if the application exists and save the app name to delete it later
         application_name_from_config, _ = self.__config_manager.get_application_from_path(application_path)
 

--- a/src/cli/api/local_api.py
+++ b/src/cli/api/local_api.py
@@ -374,7 +374,9 @@ class LocalApi:
         application_path = path / application_name if application_name is not None else path
         # When we are not in the directory of the application, get the directory from the config
         if not application_path.is_dir() and application_name is not None:
-            application_path = Path(self.__config_manager.get_application_path(application_name))
+            app_path = self.__config_manager.get_application_path(application_name)
+            if app_path is not None:
+                application_path = Path(app_path)
 
         # check if the application exists and save the app name to delete it later
         application_name_from_config, _ = self.__config_manager.get_application_from_path(application_path)

--- a/src/cli/api/remote_api.py
+++ b/src/cli/api/remote_api.py
@@ -28,8 +28,8 @@ class RemoteApi:
     def list_applications(self) -> List[ApplicationType]:
         return []
 
-    def delete_application(self, application: str) -> None:
-        pass
+    def delete_application(self, application_name: Optional[str], path: Path) -> bool:
+        return True
 
     def upload_application(self, application: str) -> None:
         pass

--- a/src/cli/command_list.py
+++ b/src/cli/command_list.py
@@ -97,9 +97,11 @@ def applications_delete(
     application_name: Optional[str] = typer.Argument(None, help="Name of the application")
 ) -> None:
     """
-    Delete application files. Currently only local
+    Delete application files from application directory. Currently only local
 
-    When application_name is given ./application_name is taken as application path, otherwise current directory.
+    When application_name is given ./application_name is taken as application directory, when this directory is
+    not valid the application directory is fetched from the application configuration. When application_name is
+    not given, the current directory is taken as application directory.
     """
     # Temporary local only
     if application_name is not None:

--- a/src/cli/command_list.py
+++ b/src/cli/command_list.py
@@ -93,11 +93,27 @@ def applications_create(
 
 @applications_app.command("delete")
 @catch_qne_cli_exceptions
-def applications_delete() -> None:
+def applications_delete(
+    application_name: Optional[str] = typer.Argument(None, help="Name of the application")
+) -> None:
     """
-    Delete remote application.
+    Delete application files. Currently only local
+
+    When application_name is given ./application_name is taken as application path, otherwise current directory.
     """
-    raise CommandNotImplemented
+    # Temporary local only
+    if application_name is not None:
+        validate_path_name("Application", application_name)
+
+    cwd = Path.cwd()
+    deleted_completely = processor.applications_delete(application_name, path=cwd)
+    if deleted_completely:
+        typer.echo("Application deleted successfully")
+    else:
+        if application_name is None:
+            typer.echo("Application files deleted")
+        else:
+            typer.echo("Application files deleted, directory not empty")
 
 
 @applications_app.command("init")
@@ -256,7 +272,6 @@ def experiments_delete(
             typer.echo("Experiment files deleted")
         else:
             typer.echo("Experiment files deleted, directory not empty")
-
 
 
 @experiments_app.command("run")

--- a/src/cli/command_processor.py
+++ b/src/cli/command_processor.py
@@ -60,8 +60,12 @@ class CommandProcessor:
         return app_list
 
     @log_function
-    def applications_delete(self, application_name: str) -> None:
-        self.__remote.delete_application(application_name)
+    def applications_delete(self, application_name: Optional[str], path: Path) -> bool:
+        # be sure to call both local and remote
+        deleted_completely_local = self.__local.delete_application(application_name, path)
+        deleted_completely_remote = self.__remote.delete_application(application_name, path)
+
+        return deleted_completely_local and deleted_completely_remote
 
     @log_function
     def applications_publish(self, application_name: str) -> None:

--- a/src/cli/exceptions.py
+++ b/src/cli/exceptions.py
@@ -14,10 +14,10 @@ class ApplicationAlreadyExists(QneCliException):
 
 class ApplicationDoesNotExist(QneCliException):
     """Raised when application path (the current path the user is in) doesn't match any of the application paths in
-    .qne/application.json"""
+    .qne/application.json or when application path isn't identified as an application directory"""
 
-    def __init__(self) -> None:
-        super().__init__("Current directory does not appear to be a valid application directory")
+    def __init__(self, application_path: str) -> None:
+        super().__init__(f"Directory '{application_path}' does not appear to be a valid application directory")
 
 
 class ApplicationNotFound(QneCliException):

--- a/src/cli/managers/config_manager.py
+++ b/src/cli/managers/config_manager.py
@@ -110,7 +110,7 @@ class ConfigManager:
                 return application
         return None
 
-    def get_application_path(self, application_name: str) -> Optional[str]:
+    def get_application_path(self, application_name: str) -> Any:
         """
         Reads the applications.json config file for getting the path using the application_name.
 

--- a/src/cli/managers/config_manager.py
+++ b/src/cli/managers/config_manager.py
@@ -110,7 +110,7 @@ class ConfigManager:
                 return application
         return None
 
-    def get_application_path(self, application_name: str) -> Any:
+    def get_application_path(self, application_name: str) -> Optional[str]:
         """
         Reads the applications.json config file for getting the path using the application_name.
 

--- a/src/cli/managers/config_manager.py
+++ b/src/cli/managers/config_manager.py
@@ -56,7 +56,25 @@ class ConfigManager:
         write_json_file(self.applications_config, applications)
 
     def delete_application(self, application_name: str) -> None:
-        pass
+        """
+        Takes care of deleting the application from the .qne/application.json root file together with the application
+        data.
+
+        Args:
+            application_name: name of the application
+
+        """
+        # application name is stored in lowercase
+        application_name = application_name.lower()
+
+        # Read json file
+        applications = read_json_file(self.applications_config)
+
+        # Remove the app and write
+        if application_name in applications:
+            del applications[application_name]
+
+            write_json_file(self.applications_config, applications)
 
     def get_applications(self) -> List[Dict[str, Any]]:
         """
@@ -118,7 +136,7 @@ class ConfigManager:
             if application_path is not None and application_path == os.path.join(str(path), ''):
                 return application_name, applications[application_name]
 
-        raise ApplicationDoesNotExist()
+        raise ApplicationDoesNotExist(str(path))
 
     def application_exists(self, application_name: str) -> Tuple[bool, Any]:
         """

--- a/src/tests/api/test_local_api.py
+++ b/src/tests/api/test_local_api.py
@@ -549,6 +549,20 @@ class ApplicationValidate(AppValidate):
             self.assertEqual(rmdir_mock.call_count, 1)
             self.assertFalse(delete_application_output)
 
+    def test_delete_application_path_from_configuration_not_valid(self):
+        with patch("cli.api.local_api.Path.is_dir") as is_dir_mock, \
+             patch("cli.api.local_api.Path.is_file", return_value=True) as is_file_mock, \
+             patch("cli.api.local_api.Path.unlink") as unlink_mock, \
+             patch.object(self.config_manager, "get_application_path", return_value=None), \
+             patch.object(self.config_manager, "get_application_from_path") as resulting_path_mock, \
+             patch.object(self.config_manager, "delete_application"), \
+             patch.object(LocalApi, "_LocalApi__get_role_names", return_value=['Sender', 'Receiver']), \
+             patch("cli.api.local_api.os.rmdir") as rmdir_mock:
+
+            resulting_path_mock.return_value=('app_dir', None)
+            is_dir_mock.side_effect = [False, False]
+            self.assertRaises(ApplicationDoesNotExist, self.local_api.delete_application, 'app_dir', path=Path('dummy'))
+
     def test_delete_application_no_application_directory(self):
         with patch("cli.api.local_api.Path.is_dir", return_value=True), \
              patch("cli.api.local_api.Path.is_file", return_value=True), \

--- a/src/tests/api/test_local_api.py
+++ b/src/tests/api/test_local_api.py
@@ -402,10 +402,11 @@ class ApplicationValidate(AppValidate):
             self.assertIsNone(config)
 
     def test_delete_application_invalid_application_dir(self):
-        with patch("cli.api.local_api.Path.is_dir", return_value=False), \
+        with patch("cli.api.local_api.Path.is_dir") as is_dir_mock, \
              patch.object(self.config_manager, "get_application_from_path", return_value=('app_dir', None)), \
              patch("cli.api.local_api.Path.is_file", return_value=False):
 
+            is_dir_mock.side_effect = [True, False]
             self.assertRaises(ApplicationDoesNotExist, self.local_api.delete_application, 'app_dir', self.path)
 
     def test_delete_application_src_dir(self):
@@ -417,7 +418,7 @@ class ApplicationValidate(AppValidate):
              patch.object(LocalApi, "_LocalApi__get_role_names", return_value=['Sender', 'Receiver']), \
              patch("cli.api.local_api.os.rmdir") as rmdir_mock:
 
-            is_dir_mock.side_effect = [True, True, True, False]
+            is_dir_mock.side_effect = [True, True, True, True, False]
             is_file_mock.side_effect = [True, True, True, True, True, True, True, True, True]
             rmdir_mock.side_effect = [None, None]
 
@@ -432,7 +433,7 @@ class ApplicationValidate(AppValidate):
             is_dir_mock.reset_mock()
             is_file_mock.reset_mock()
 
-            is_dir_mock.side_effect = [True, True, True, False]
+            is_dir_mock.side_effect = [True, True, True, True, False]
             is_file_mock.side_effect = [True, True, True, True, True, True, True, True, True]
             rmdir_mock.side_effect = [OSError, None]
 
@@ -447,7 +448,7 @@ class ApplicationValidate(AppValidate):
             is_dir_mock.reset_mock()
             is_file_mock.reset_mock()
 
-            is_dir_mock.side_effect = [True, True, True, False]
+            is_dir_mock.side_effect = [True, True, True, True, False]
             is_file_mock.side_effect = [False, True, True, True, True]
             rmdir_mock.side_effect = [OSError, None]
 
@@ -463,7 +464,7 @@ class ApplicationValidate(AppValidate):
              patch.object(self.config_manager, "get_application_from_path", return_value=('app_dir', None)), \
              patch("cli.api.local_api.os.rmdir") as rmdir_mock:
 
-            is_dir_mock.side_effect = [True, False, True, True]
+            is_dir_mock.side_effect = [True, True, False, True, True]
             is_file_mock.side_effect = [True, True, True, True, True]
 
             delete_application_output = self.local_api.delete_application('app_dir', path=Path('dummy'))
@@ -477,7 +478,7 @@ class ApplicationValidate(AppValidate):
             is_dir_mock.reset_mock()
             is_file_mock.reset_mock()
 
-            is_dir_mock.side_effect = [True, False, True, True]
+            is_dir_mock.side_effect = [True, True, False, True, True]
             is_file_mock.side_effect = [True, True, True, True, True]
             rmdir_mock.side_effect = [OSError, None]
 
@@ -506,7 +507,40 @@ class ApplicationValidate(AppValidate):
             is_dir_mock.reset_mock()
             is_file_mock.reset_mock()
 
-            is_dir_mock.side_effect = [True, False, False, True]
+            is_dir_mock.side_effect = [True, True, False, False, True]
+            is_file_mock.side_effect = [True, True, True, True, True]
+            rmdir_mock.side_effect = [OSError]
+
+            delete_application_output = self.local_api.delete_application('app_dir', path=Path('dummy'))
+            self.assertEqual(unlink_mock.call_count, 1)
+            self.assertEqual(rmdir_mock.call_count, 1)
+            self.assertFalse(delete_application_output)
+
+    def test_delete_application_path_from_configuration(self):
+        with patch("cli.api.local_api.Path.is_dir") as is_dir_mock, \
+             patch("cli.api.local_api.Path.is_file", return_value=True) as is_file_mock, \
+             patch("cli.api.local_api.Path.unlink") as unlink_mock, \
+             patch.object(self.config_manager, "get_application_path", return_value='other_path'), \
+             patch.object(self.config_manager, "get_application_from_path") as resulting_path_mock, \
+             patch.object(self.config_manager, "delete_application"), \
+             patch.object(LocalApi, "_LocalApi__get_role_names", return_value=['Sender', 'Receiver']), \
+             patch("cli.api.local_api.os.rmdir") as rmdir_mock:
+
+            resulting_path_mock.return_value=('app_dir', None)
+            is_dir_mock.side_effect = [False, True, True, True, True]
+            delete_application_output = self.local_api.delete_application('app_dir', path=Path('dummy'))
+            resulting_path_mock.assert_called_once_with(Path('other_path'))
+            self.assertEqual(unlink_mock.call_count, 6)
+            self.assertEqual(rmdir_mock.call_count, 3)
+            self.assertTrue(delete_application_output)
+
+            # rmdir directory application_path fails
+            unlink_mock.reset_mock()
+            rmdir_mock.reset_mock()
+            is_dir_mock.reset_mock()
+            is_file_mock.reset_mock()
+
+            is_dir_mock.side_effect = [True, True, False, False, True]
             is_file_mock.side_effect = [True, True, True, True, True]
             rmdir_mock.side_effect = [OSError]
 

--- a/src/tests/api/test_local_api.py
+++ b/src/tests/api/test_local_api.py
@@ -551,13 +551,13 @@ class ApplicationValidate(AppValidate):
 
     def test_delete_application_path_from_configuration_not_valid(self):
         with patch("cli.api.local_api.Path.is_dir") as is_dir_mock, \
-             patch("cli.api.local_api.Path.is_file", return_value=True) as is_file_mock, \
-             patch("cli.api.local_api.Path.unlink") as unlink_mock, \
+             patch("cli.api.local_api.Path.is_file", return_value=True), \
+             patch("cli.api.local_api.Path.unlink"), \
              patch.object(self.config_manager, "get_application_path", return_value=None), \
              patch.object(self.config_manager, "get_application_from_path") as resulting_path_mock, \
              patch.object(self.config_manager, "delete_application"), \
              patch.object(LocalApi, "_LocalApi__get_role_names", return_value=['Sender', 'Receiver']), \
-             patch("cli.api.local_api.os.rmdir") as rmdir_mock:
+             patch("cli.api.local_api.os.rmdir"):
 
             resulting_path_mock.return_value=('app_dir', None)
             is_dir_mock.side_effect = [False, False]

--- a/src/tests/test_command_list.py
+++ b/src/tests/test_command_list.py
@@ -108,6 +108,41 @@ class TestCommandList(unittest.TestCase):
                                                            ['create', 'test_application', 'role1', 'role2'])
             self.assertIn("Unhandled exception: Exception('Test')", application_create_output.stdout)
 
+    def test_application_delete_no_experiment_dir(self):
+        with patch("cli.command_list.Path.cwd", return_value='test') as mock_cwd, \
+             patch("cli.command_list.validate_path_name") as mock_validate_path_name, \
+             patch.object(CommandProcessor, 'applications_delete', return_value=True) as applications_delete_mock:
+
+            application_delete_output = self.runner.invoke(applications_app, ['delete'])
+            mock_cwd.assert_called_once()
+            self.assertEqual(mock_validate_path_name.call_count, 0)
+            self.assertEqual(application_delete_output.exit_code, 0)
+            self.assertIn("Application deleted successfully",
+                          application_delete_output.stdout)
+
+            applications_delete_mock.return_value = False
+            mock_cwd.reset_mock()
+            mock_validate_path_name.reset_mock()
+            application_delete_output = self.runner.invoke(applications_app, ['delete'])
+            mock_cwd.assert_called_once()
+            self.assertEqual(mock_validate_path_name.call_count, 0)
+            self.assertEqual(application_delete_output.exit_code, 0)
+            self.assertIn("Application files deleted",
+                          application_delete_output.stdout)
+
+    def test_application_delete_with_application_dir(self):
+        with patch("cli.command_list.Path.cwd", return_value='test') as mock_cwd, \
+             patch("cli.command_list.validate_path_name") as mock_validate_path_name, \
+             patch.object(CommandProcessor, 'applications_delete', return_value=False) as applications_delete_mock:
+
+            application_delete_output = self.runner.invoke(applications_app, ['delete', 'app_dir'])
+            mock_cwd.assert_called_once()
+            self.assertEqual(mock_validate_path_name.call_count, 1)
+            applications_delete_mock.assert_called_once()
+            self.assertEqual(application_delete_output.exit_code, 0)
+            self.assertIn("Application files deleted, directory not empty",
+                          application_delete_output.stdout)
+
     def test_experiment_delete_no_experiment_dir(self):
         with patch("cli.command_list.Path.cwd", return_value='test') as mock_cwd, \
              patch("cli.command_list.validate_path_name") as mock_validate_path_name, \

--- a/src/tests/test_command_processor.py
+++ b/src/tests/test_command_processor.py
@@ -44,6 +44,26 @@ class TestCommandProcessor(unittest.TestCase):
             self.processor.applications_validate(self.application)
             is_application_valid_mock.assert_called_once_with(self.application)
 
+    def test_application_delete(self):
+        with patch.object(LocalApi, "delete_application") as local_delete_application_mock, \
+             patch.object(RemoteApi, "delete_application") as remote_delete_application_mock:
+
+            local_delete_application_mock.return_value = True
+            remote_delete_application_mock.return_value = True
+            return_value = self.processor.applications_delete(None, path=Path('dummy'))
+            local_delete_application_mock.assert_called_once()
+            remote_delete_application_mock.assert_called_once()
+            self.assertTrue(return_value)
+
+            local_delete_application_mock.reset_mock()
+            remote_delete_application_mock.reset_mock()
+            local_delete_application_mock.return_value = False
+            remote_delete_application_mock.return_value = False
+            return_value = self.processor.applications_delete(None, path=Path('dummy'))
+            local_delete_application_mock.assert_called_once()
+            remote_delete_application_mock.assert_called_once()
+            self.assertFalse(return_value)
+
     def test_experiments_create_local(self):
         with patch.object(LocalApi, "experiments_create") as create_exp_mock, \
              patch.object(LocalApi, "get_application_config") as get_config_mock, \
@@ -102,7 +122,6 @@ class TestCommandProcessor(unittest.TestCase):
             local_delete_experiment_mock.assert_called_once()
             remote_delete_experiment_mock.assert_called_once()
             self.assertFalse(return_value)
-
 
     def test_experiments_validate(self):
         with patch.object(LocalApi, "validate_experiment") as validate_exp_mock:

--- a/src/tests/test_command_processor.py
+++ b/src/tests/test_command_processor.py
@@ -140,6 +140,8 @@ class TestCommandProcessor(unittest.TestCase):
 
     def test_experiments_run(self):
         with patch.object(LocalApi, "is_experiment_local") as is_exp_local_mock, \
+             patch('cli.command_processor.Path.mkdir'), \
+             patch("cli.command_processor.utils.write_json_file"), \
              patch.object(LocalApi, "run_experiment") as run_exp_mock:
 
             is_exp_local_mock.return_value = True


### PR DESCRIPTION
* Similar to experiment delete
* Local only
* >qne application delete (application in current directory)
* >qne application delete app (application in directory .\app OR application not in .\app but application path found in application config)
* unit tests
* Some side effect from unit test run experiment solved that created directory
